### PR TITLE
Improve Apple HIG compliance across the site

### DIFF
--- a/src/components/Categories.astro
+++ b/src/components/Categories.astro
@@ -49,7 +49,7 @@ const categories = [
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.03em;
-    border-radius: 3px;
+    border-radius: 4px;
     transition: background-color 0.2s ease;
     border: 1px solid var(--color-text-primary);
   }

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -37,7 +37,9 @@ const currentYear = new Date().getFullYear();
   .footer-content {
     max-width: var(--max-width);
     margin: 0 auto;
-    padding: 0 var(--content-padding);
+    padding: 0 max(var(--content-padding), env(safe-area-inset-right)) 0
+      max(var(--content-padding), env(safe-area-inset-left));
+    padding-bottom: env(safe-area-inset-bottom, 0);
     display: flex;
     align-items: center;
     justify-content: space-between;

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -170,7 +170,8 @@ const base = Astro.site ? config.baseUrl : "";
   .header-content {
     max-width: var(--max-width);
     margin: 0 auto;
-    padding: 0 var(--content-padding);
+    padding: 0 max(var(--content-padding), env(safe-area-inset-right)) 0
+      max(var(--content-padding), env(safe-area-inset-left));
     display: flex;
     align-items: center;
     justify-content: space-between;

--- a/src/components/HeaderMobileMenu.astro
+++ b/src/components/HeaderMobileMenu.astro
@@ -32,9 +32,12 @@ const { base } = Astro.props;
     background-color: var(--color-background);
     z-index: 99;
     transform: translateX(-100%);
-    transition: transform 0.3s ease;
+    transition: transform 0.35s cubic-bezier(0.2, 0.9, 0.3, 1);
     overflow-y: auto;
     padding-top: calc(var(--grid-unit) * 12);
+    padding-bottom: env(safe-area-inset-bottom, 0);
+    padding-left: env(safe-area-inset-left, 0);
+    padding-right: env(safe-area-inset-right, 0);
   }
 
   .mobile-menu.active {

--- a/src/components/HeaderSearch.astro
+++ b/src/components/HeaderSearch.astro
@@ -9,11 +9,12 @@
     <div class="search-header">
       <label for="search-input" class="sr-only">Search articles</label>
       <input
-        type="text"
+        type="search"
         class="search-input"
         id="search-input"
         placeholder="Search articles..."
         autocomplete="off"
+        enterkeyhint="search"
       />
       <button class="search-close" id="search-close" aria-label="Close search">
         <svg
@@ -232,13 +233,15 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background: rgba(0, 0, 0, 0.8);
+    background: rgba(0, 0, 0, 0.4);
+    -webkit-backdrop-filter: blur(20px);
+    backdrop-filter: blur(20px);
     z-index: 1000;
     opacity: 0;
     visibility: hidden;
     transition:
-      opacity 0.3s ease,
-      visibility 0.3s ease;
+      opacity 0.35s cubic-bezier(0.2, 0.9, 0.3, 1),
+      visibility 0.35s cubic-bezier(0.2, 0.9, 0.3, 1);
   }
 
   .search-overlay.active {
@@ -249,7 +252,8 @@
   .search-container {
     max-width: 800px;
     margin: calc(var(--grid-unit) * 10) auto calc(var(--grid-unit) * 4) auto;
-    padding: 0 var(--content-padding);
+    padding: 0 max(var(--content-padding), env(safe-area-inset-right)) 0
+      max(var(--content-padding), env(safe-area-inset-left));
   }
 
   .search-header {
@@ -257,7 +261,7 @@
     align-items: center;
     background: var(--color-background);
     border: 2px solid var(--color-border);
-    border-radius: 8px;
+    border-radius: 12px;
     padding: calc(var(--grid-unit) * 3);
     margin-bottom: calc(var(--grid-unit) * 5);
   }
@@ -285,7 +289,9 @@
     background: none;
     border: none;
     color: var(--color-text-muted);
-    padding: calc(var(--grid-unit) / 2);
+    padding: calc(var(--grid-unit) * 1.25);
+    min-width: 44px;
+    min-height: 44px;
     cursor: pointer;
     transition: color 0.2s ease;
     display: flex;
@@ -302,9 +308,9 @@
     min-height: 40vh;
     overflow-y: auto;
     background: var(--color-background);
-    border-radius: 8px;
+    border-radius: 12px;
     border: 1px solid var(--color-border);
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
     padding: calc(var(--grid-unit) * 3) calc(var(--grid-unit) * 4) calc(var(--grid-unit) * 4)
       calc(var(--grid-unit) * 4);
   }
@@ -334,9 +340,10 @@
   }
 
   .search-result {
-    padding: calc(var(--grid-unit) * 6) calc(var(--grid-unit) * 6);
+    padding: calc(var(--grid-unit) * 3);
     margin-bottom: calc(var(--grid-unit) * 2);
     border-bottom: 1px solid var(--color-border);
+    border-radius: 8px;
     transition: background-color 0.2s ease;
   }
 
@@ -399,7 +406,7 @@
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    border-radius: 3px;
+    border-radius: 4px;
     transition: all 0.2s ease;
   }
 

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -36,7 +36,11 @@ const {
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="theme-color" content="#f5f5f5" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0a0a0a" media="(prefers-color-scheme: dark)" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
@@ -104,7 +108,8 @@ const {
     flex: 1;
     max-width: var(--max-width);
     margin: 0 auto;
-    padding: 0 var(--content-padding);
+    padding: 0 max(var(--content-padding), env(safe-area-inset-right)) 0
+      max(var(--content-padding), env(safe-area-inset-left));
     width: 100%;
   }
 

--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -16,7 +16,7 @@ import RecentPosts from "./RecentPosts.astro";
     padding: calc(var(--grid-unit) * 3);
     background-color: var(--color-surface);
     border: 1px solid var(--color-border);
-    border-radius: 4px;
+    border-radius: 12px;
   }
 
   @media (max-width: 1023px) {

--- a/src/components/SocialLinks.astro
+++ b/src/components/SocialLinks.astro
@@ -34,11 +34,11 @@ const { size = 20 } = Astro.props;
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 40px;
-    height: 40px;
+    width: 44px;
+    height: 44px;
     background-color: var(--color-text-primary);
     color: var(--color-background);
-    border-radius: 4px;
+    border-radius: 8px;
     transition: all 0.2s ease;
   }
 

--- a/src/components/SolidarityCard.astro
+++ b/src/components/SolidarityCard.astro
@@ -25,17 +25,20 @@ const { title, description, url, ariaLabel } = Astro.props;
   .solidarity-card {
     background-color: var(--color-surface);
     border: 1px solid var(--color-border);
-    border-radius: 8px;
+    border-radius: 12px;
     padding: calc(var(--grid-unit) * 4);
     text-align: center;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
     transition:
       transform 0.3s ease,
-      border-color 0.3s ease;
+      border-color 0.3s ease,
+      box-shadow 0.3s ease;
   }
 
   .solidarity-card:hover {
     transform: translateY(-4px);
     border-color: var(--color-accent);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
   }
 
   .solidarity-title {
@@ -59,7 +62,7 @@ const { title, description, url, ariaLabel } = Astro.props;
     padding: calc(var(--grid-unit) * 1.5) calc(var(--grid-unit) * 3);
     background: var(--color-accent);
     color: white;
-    border-radius: 4px;
+    border-radius: 8px;
     text-decoration: none;
     font-weight: 700;
     text-transform: uppercase;

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -59,7 +59,7 @@ const description = "Sorry, the page you are looking for does not exist.";
     background: none;
     border: none;
     padding: 0.75em 2em;
-    border-radius: 4px;
+    border-radius: 8px;
     cursor: pointer;
     transition:
       color 0.2s,

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -225,7 +225,7 @@ const sortedPosts = sortByDateDesc(filterPublished(getAllPosts()))
     text-transform: uppercase;
     letter-spacing: 0.05em;
     padding: calc(var(--grid-unit) * 1.5) calc(var(--grid-unit) * 3);
-    border-radius: 4px;
+    border-radius: 8px;
     transition: all 0.3s ease;
     text-decoration: none;
     display: inline-block;
@@ -269,17 +269,20 @@ const sortedPosts = sortByDateDesc(filterPublished(getAllPosts()))
   .theoretical-foundations-card {
     background-color: var(--color-surface);
     border: 1px solid var(--color-border);
-    border-radius: 8px;
+    border-radius: 12px;
     padding: calc(var(--grid-unit) * 4);
     text-align: center;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
     transition:
       transform 0.3s ease,
-      border-color 0.3s ease;
+      border-color 0.3s ease,
+      box-shadow 0.3s ease;
   }
 
   .theoretical-foundations-card:hover {
     transform: translateY(-4px);
     border-color: var(--color-accent);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
   }
 
   .theoretical-foundations-title {
@@ -322,16 +325,19 @@ const sortedPosts = sortByDateDesc(filterPublished(getAllPosts()))
   .dispatches-post-card {
     background-color: var(--color-surface);
     border: 1px solid var(--color-border);
-    border-radius: 8px;
+    border-radius: 12px;
     padding: calc(var(--grid-unit) * 3);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
     transition:
       transform 0.2s ease,
-      border-color 0.2s ease;
+      border-color 0.2s ease,
+      box-shadow 0.2s ease;
   }
 
   .dispatches-post-card:hover {
     transform: translateY(-2px);
     border-color: var(--color-accent);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.1);
   }
 
   .dispatches-post-title {
@@ -422,7 +428,7 @@ const sortedPosts = sortByDateDesc(filterPublished(getAllPosts()))
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    border-radius: 2px;
+    border-radius: 4px;
     border: 1px solid var(--color-text-primary);
   }
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -38,10 +38,11 @@ input {
 
 html {
   font-family: var(--font-body);
-  font-size: 16px;
+  font-size: 100%;
   line-height: 1.6;
   color: var(--color-text-primary);
   background-color: var(--color-background);
+  -webkit-tap-highlight-color: transparent;
 }
 
 body {

--- a/src/styles/elements.css
+++ b/src/styles/elements.css
@@ -32,8 +32,8 @@ code {
   font-family: var(--font-mono);
   font-size: 0.9em;
   background-color: var(--color-surface);
-  padding: 2px 4px;
-  border-radius: 3px;
+  padding: 2px 6px;
+  border-radius: 4px;
   border: 1px solid var(--color-border);
 }
 
@@ -44,7 +44,7 @@ pre {
   padding: calc(var(--grid-unit) * 2);
   margin: calc(var(--grid-unit) * 3) 0;
   overflow-x: auto;
-  border-radius: 4px;
+  border-radius: 8px;
 }
 
 pre code {
@@ -65,7 +65,7 @@ figcaption {
   font-size: 0.9rem;
   color: var(--color-text-muted);
   text-align: center;
-  margin-top: calc(var(--grid-unit) / 16);
+  margin-top: var(--grid-unit);
 }
 
 hr {

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -13,7 +13,7 @@ h6 {
 
 h1 {
   font-family: var(--font-heading-primary);
-  font-size: 2.5rem;
+  font-size: clamp(1.75rem, 4vw + 0.5rem, 2.5rem);
   font-weight: 700;
   line-height: 1.1;
   letter-spacing: 0.15em;
@@ -22,7 +22,7 @@ h1 {
 
 h2 {
   font-family: var(--font-heading-secondary);
-  font-size: 2rem;
+  font-size: clamp(1.5rem, 3vw + 0.25rem, 2rem);
   font-weight: 700;
   line-height: 1.2;
   letter-spacing: 0.1em;
@@ -30,7 +30,7 @@ h2 {
 
 h3 {
   font-family: var(--font-heading-secondary);
-  font-size: 1.5rem;
+  font-size: clamp(1.25rem, 2vw + 0.25rem, 1.5rem);
   font-weight: 600;
   line-height: 1.3;
   letter-spacing: 0.08em;

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -120,7 +120,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  border-radius: 2px;
+  border-radius: 4px;
   border: 1px solid var(--color-text-primary);
 }
 

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -1,7 +1,7 @@
 :root {
   --color-white: #ffffff;
   --color-light-gray: #f5f5f5;
-  --color-medium-gray: #888888;
+  --color-medium-gray: #666666;
   --color-muted-gray: #222222;
   --color-dark-gray: #333333;
   --color-black: #000000;
@@ -45,7 +45,7 @@
     --color-text-primary: #f5f5f5;
     --color-text-secondary: #b8b8b8;
     --color-text-muted: #cccccc;
-    --color-border: #404040;
+    --color-border: #5a5a5a;
     --color-accent: #ff3333;
 
     --color-surface-alt: #222222;


### PR DESCRIPTION
Address safe area insets for notched iPhones (viewport-fit=cover),
fix border contrast ratios for WCAG AA compliance, add backdrop blur
to search overlay, fluid typography with clamp(), consistent border
radius tiers (4/8/12px), card depth shadows, 44px touch targets,
theme-color and apple-mobile-web-app meta tags, and Dynamic Type
support by removing fixed font-size on html.

https://claude.ai/code/session_01Qk7r8d9cgUzaDN7dDVgMCe