### PR TITLE
Update privacy policy for Cloudflare analytics accuracy

### DIFF
--- a/src/pages/privacy-policy.astro
+++ b/src/pages/privacy-policy.astro
@@ -14,7 +14,7 @@ const pageDescription = `Privacy policy for ${title}`;
     </header>
 
     <div class="content-section">
-      <p class="last-updated">Last updated: 27 October 2025</p>
+      <p class="last-updated">Last updated: 8 April 2026</p>
 
       <h2>1. Introduction</h2>
       <p>
@@ -32,7 +32,11 @@ const pageDescription = `Privacy policy for ${title}`;
       </p>
       <ul>
         <li>No cookies are used.</li>
-        <li>No personal data (such as IP addresses or unique identifiers) are collected.</li>
+        <li>
+          No personal data is collected or stored by us. Cloudflare may transiently process IP
+          addresses server-side solely to derive aggregate country-level data; we never see
+          individual IP addresses or identifiers.
+        </li>
         <li>
           The information we see is aggregated and anonymous — for example, total page views,
           referring websites, and countries of origin.
@@ -76,7 +80,7 @@ const pageDescription = `Privacy policy for ${title}`;
       <p>For any privacy-related questions, you can reach out to:</p>
       <p>The Red Soil<br />Email: contact@theredsoil.co.za</p>
 
-      <h2>Summary</h2>
+      <h2>8. Summary</h2>
       <p>
         We don't track you. We don't use cookies. We don't sell or share data. We only see anonymous
         stats to understand how the site performs — nothing more.


### PR DESCRIPTION
## Summary

- Clarifies that Cloudflare transiently processes IP addresses server-side to derive aggregate country-level data (site owner never sees individual IPs)
- Numbers the "Summary" section as §8 for consistency with the rest of the document
- Updates the last-modified date to 8 April 2026

## Test plan

- [ ] Visit `/privacy-policy` and verify the updated bullet point reads correctly
- [ ] Confirm section numbering is consistent (1–8)
- [ ] Confirm last updated date shows 8 April 2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)