### PR TITLE
Fix perf, a11y, and styling issues across the site

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -34,11 +34,6 @@ export default defineConfig({
   prefetch: {
     defaultStrategy: "hover",
   },
-  image: {
-    service: {
-      entrypoint: "astro/assets/services/sharp",
-    },
-  },
   build: {
     assetsInlineLimit: 4096,
     cacheDir: "./.astro-cache",

--- a/src/components/BookmarkNav.astro
+++ b/src/components/BookmarkNav.astro
@@ -221,7 +221,7 @@ const { sections, ariaLabel = "Category navigation" } = Astro.props;
     }
 
     .bookmark-list {
-      display: flex !important;
+      display: flex;
     }
   }
 </style>

--- a/src/components/HeaderSearch.astro
+++ b/src/components/HeaderSearch.astro
@@ -250,7 +250,7 @@
   }
 
   .search-container {
-    max-width: 800px;
+    max-width: var(--content-width);
     margin: calc(var(--grid-unit) * 10) auto calc(var(--grid-unit) * 4) auto;
     padding: 0 max(var(--content-padding), env(safe-area-inset-right)) 0
       max(var(--content-padding), env(safe-area-inset-left));

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -11,6 +11,7 @@ export interface Props {
   title: string;
   description?: string;
   showSidebar?: boolean;
+  preloadMonoFont?: boolean;
   image?: string;
   type?: "website" | "article";
   datePublished?: string;
@@ -23,6 +24,7 @@ const {
   title,
   description,
   showSidebar = true,
+  preloadMonoFont = false,
   image,
   type,
   datePublished,
@@ -48,7 +50,7 @@ const {
     <link rel="sitemap" href="/sitemap-index.xml" />
     <Font cssVariable="--font-oswald" preload />
     <Font cssVariable="--font-work-sans" preload />
-    <Font cssVariable="--font-jetbrains-mono" preload />
+    <Font cssVariable="--font-jetbrains-mono" preload={preloadMonoFont} />
     <SEO
       title={title}
       description={description}
@@ -64,7 +66,12 @@ const {
     <a href="#main-content" class="skip-link">Skip to content</a>
     <div class="site-wrapper">
       <Header />
-      <main id="main-content" class="main-content" class:list={{ "with-sidebar": showSidebar }}>
+      <main
+        id="main-content"
+        class="main-content"
+        class:list={{ "with-sidebar": showSidebar }}
+        aria-label="Main content"
+      >
         {
           showSidebar && (
             <aside class="sidebar">

--- a/src/components/SolidarityCard.astro
+++ b/src/components/SolidarityCard.astro
@@ -61,7 +61,7 @@ const { title, description, url, ariaLabel } = Astro.props;
     display: inline-block;
     padding: calc(var(--grid-unit) * 1.5) calc(var(--grid-unit) * 3);
     background: var(--color-accent);
-    color: white;
+    color: var(--color-white);
     border-radius: 8px;
     text-decoration: none;
     font-weight: 700;

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -96,7 +96,7 @@ const pageDescription = `Learn more about ${title} publication and its mission`;
 
 <style>
   .about-page {
-    max-width: 800px;
+    max-width: var(--content-width);
     margin: 0 auto;
   }
 

--- a/src/pages/categories/[category].astro
+++ b/src/pages/categories/[category].astro
@@ -82,7 +82,7 @@ const base = config.baseUrl;
 
 <style>
   .category-page {
-    max-width: 800px;
+    max-width: var(--content-width);
     margin: 0 auto;
   }
 
@@ -138,7 +138,7 @@ const base = config.baseUrl;
   .back-link:hover,
   .back-link:focus {
     background-color: var(--color-accent);
-    color: white;
+    color: var(--color-white);
     text-decoration: none;
   }
 

--- a/src/pages/dispatches.astro
+++ b/src/pages/dispatches.astro
@@ -53,7 +53,7 @@ const sortedPosts = sortByDateDesc(filterPublished(getAllPosts()));
                 data-astro-prefetch
                 class="read-more"
               >
-                Read More →
+                Read More <span aria-hidden="true">→</span>
               </a>
             </article>
           ))}
@@ -72,7 +72,7 @@ const sortedPosts = sortByDateDesc(filterPublished(getAllPosts()));
 
 <style>
   .dispatches-page {
-    max-width: 800px;
+    max-width: var(--content-width);
     margin: 0 auto;
   }
 

--- a/src/pages/dispatches/[...slug].astro
+++ b/src/pages/dispatches/[...slug].astro
@@ -45,6 +45,7 @@ const dateModified = frontmatter.dateModified
   datePublished={datePublished}
   dateModified={dateModified}
   image={frontmatter.image}
+  preloadMonoFont
 >
   <article class="dispatches-post">
     <header class="post-header">
@@ -129,7 +130,7 @@ const dateModified = frontmatter.dateModified
 
 <style>
   .dispatches-post {
-    max-width: 800px;
+    max-width: var(--content-width);
     margin: 0 auto;
   }
 
@@ -446,7 +447,7 @@ const dateModified = frontmatter.dateModified
   .back-to-dispatches:hover,
   .back-to-dispatches:focus {
     background-color: var(--color-accent);
-    color: white;
+    color: var(--color-white);
     text-decoration: none;
   }
 

--- a/src/pages/feed.json.ts
+++ b/src/pages/feed.json.ts
@@ -25,7 +25,7 @@ export const GET: APIRoute = async (context) => {
     })),
   };
 
-  return new Response(JSON.stringify(feed, null, 2), {
+  return Response.json(feed, {
     headers: {
       "Content-Type": "application/feed+json; charset=utf-8",
     },

--- a/src/pages/feeds.astro
+++ b/src/pages/feeds.astro
@@ -110,7 +110,7 @@ import { withBase } from "../utils/url";
 
 <style>
   .feeds-page {
-    max-width: 800px;
+    max-width: var(--content-width);
     margin: 0 auto;
   }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -168,7 +168,7 @@ const sortedPosts = sortByDateDesc(filterPublished(getAllPosts()))
   }
 
   .hero-content {
-    max-width: 800px;
+    max-width: var(--content-width);
     margin: 0 auto;
     padding: 0 var(--content-padding);
   }
@@ -234,7 +234,7 @@ const sortedPosts = sortByDateDesc(filterPublished(getAllPosts()))
 
   .btn-primary {
     background-color: var(--color-accent);
-    color: white;
+    color: var(--color-white);
     border: 2px solid var(--color-accent);
   }
 

--- a/src/pages/privacy-policy.astro
+++ b/src/pages/privacy-policy.astro
@@ -91,7 +91,7 @@ const pageDescription = `Privacy policy for ${title}`;
 
 <style>
   .privacy-page {
-    max-width: 800px;
+    max-width: var(--content-width);
     margin: 0 auto;
   }
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -9,23 +9,15 @@ html {
   }
 }
 
+html,
 body,
 a,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-span,
-div,
 button,
 input {
   transition:
-    background-color 0.3s ease,
-    color 0.3s ease,
-    border-color 0.3s ease;
+    background-color var(--transition-slow) ease,
+    color var(--transition-slow) ease,
+    border-color var(--transition-slow) ease;
 }
 
 *,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,3 +3,4 @@
 @import "./typography.css";
 @import "./elements.css";
 @import "./utilities.css";
+@import "./print.css";

--- a/src/styles/print.css
+++ b/src/styles/print.css
@@ -1,0 +1,70 @@
+@media print {
+  *,
+  *::before,
+  *::after {
+    background: transparent !important;
+    color: #000 !important;
+    box-shadow: none !important;
+    text-shadow: none !important;
+  }
+
+  header,
+  aside,
+  nav,
+  footer,
+  .skip-link,
+  .sidebar {
+    display: none !important;
+  }
+
+  main {
+    display: block !important;
+    max-width: 100% !important;
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+
+  a,
+  a:visited {
+    text-decoration: underline;
+  }
+
+  a[href]::after {
+    content: " (" attr(href) ")";
+    font-size: 0.85em;
+    word-break: break-all;
+  }
+
+  a[href^="#"]::after,
+  a[href^="javascript:"]::after {
+    content: "";
+  }
+
+  img {
+    max-width: 100% !important;
+    page-break-inside: avoid;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    page-break-after: avoid;
+    orphans: 3;
+    widows: 3;
+  }
+
+  p,
+  blockquote {
+    orphans: 3;
+    widows: 3;
+  }
+
+  pre,
+  blockquote {
+    border: 1px solid #999;
+    page-break-inside: avoid;
+  }
+}

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -23,8 +23,20 @@
 
   --grid-unit: 8px;
   --max-width: 1200px;
+  --content-width: 800px;
   --sidebar-width: 320px;
   --content-padding: calc(var(--grid-unit) * 3);
+
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.1);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.1);
+
+  --transition-fast: 0.15s;
+  --transition-base: 0.2s;
+  --transition-slow: 0.3s;
+
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
 
   --color-surface-alt: #eeeeee;
   --color-surface-hover: #e0e0e0;
@@ -50,5 +62,16 @@
 
     --color-surface-alt: #222222;
     --color-surface-hover: #2a2a2a;
+
+    --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.4);
+    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+
+    --code-bg: #1e1e1e;
+    --code-text: #d4d4d4;
+    --code-keyword: #569cd6;
+    --code-string: #ce9178;
+    --code-punctuation: #808080;
+    --code-comment: #6a9955;
+    --code-number: #b5cea8;
   }
 }


### PR DESCRIPTION
- Dark mode: add code syntax color overrides so code blocks are readable
- Dark mode: add --shadow-sm/--shadow-md variables with darker values for dark mode
- Design tokens: add --content-width, --transition-*, --radius-*, --shadow-* to variables.css
- Replace all hardcoded max-width: 800px with var(--content-width) across 8 files
- Replace hardcoded color: white with var(--color-white) across 4 files
- CSS transitions: narrow broad selector (h1-h6, p, span, div) to only html/body/a/button/input
- Font preload: make JetBrains Mono preload opt-in via preloadMonoFont prop; enable only on article pages
- Feed: remove pretty-printing from feed.json.ts to reduce payload size
- Config: remove unused Sharp image service configuration
- BookmarkNav: remove !important from desktop display rule
- Accessibility: add aria-label="Main content" to <main> in Layout.astro
- Accessibility: wrap arrow glyph in aria-hidden span in dispatches.astro Read More links
- Print: add print.css with sensible print styles (hide nav/aside, show link URLs)

All 106 tests pass.

https://claude.ai/code/session_014fym8G4A6GmvqGLqYkf6dJ